### PR TITLE
docs: add JavaDoc comments for global exception handling and API resp…

### DIFF
--- a/src/main/java/com/tumblermall/global/exception/ApiResponse.java
+++ b/src/main/java/com/tumblermall/global/exception/ApiResponse.java
@@ -2,7 +2,23 @@ package com.tumblermall.global.exception;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.springframework.http.HttpStatus;
 
+/**
+ * ApiResponse is a generic wrapper for standardizing API responses.
+ *
+ * <p>Responsibilities:
+ * <ul>
+ *   <li>Encapsulate the HTTP response code.</li>
+ *   <li>Provide a human-readable message describing the result.</li>
+ *   <li>Carry the actual payload data when the request is successful.</li>
+ * </ul>
+ *
+ * @param <T> the type of the response payload
+ *
+ * @author sharon
+ * @author whosoonhwang
+ */
 @ApiModel(description = "공통 API 응답")
 public class ApiResponse<T> {
 
@@ -15,17 +31,40 @@ public class ApiResponse<T> {
     @ApiModelProperty(value = "실제 데이터")
     private T data;
 
+    /**
+     * Constructs a new ApiResponse with the given code, message, and data.
+     *
+     * @param code    the HTTP-style response code
+     * @param message a descriptive message
+     * @param data    the payload data, or null if none
+     */
     public ApiResponse(int code, String message, T data) {
         this.code = code;
         this.message = message;
         this.data = data;
     }
 
+    /**
+     * Creates a successful ApiResponse containing the provided data.
+     *
+     * @param data the payload data
+     * @param <T>  the type of the payload
+     * @return an ApiResponse with code 200 and message "성공"
+     */
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(200, "성공", data);
+        return new ApiResponse<>(HttpStatus.OK.value(), "성공", data);
     }
 
+    /**
+     * Creates a failure ApiResponse with the given message.
+     *
+     * @param message the error message
+     * @param <T>     the type parameter for the payload (will be null)
+     * @return an ApiResponse with code 400 and the provided error message
+     */
     public static <T> ApiResponse<T> fail(String message) {
-        return new ApiResponse<>(400, message, null);
+        return new ApiResponse<>(HttpStatus.BAD_REQUEST.value(), message, null);
     }
+
+    // Getters and setters omitted for brevity
 }

--- a/src/main/java/com/tumblermall/global/exception/ErrorCode.java
+++ b/src/main/java/com/tumblermall/global/exception/ErrorCode.java
@@ -1,5 +1,13 @@
 package com.tumblermall.global.exception;
 
+/**
+ * 예외코드 정의
+ *
+ * @author sharon
+ * @author whosoonhwang
+ * @deprecated 사용하는 곳이 없는데? TODO
+ */
+@Deprecated
 public enum ErrorCode {
 
     // 400 Bad Request

--- a/src/main/java/com/tumblermall/global/exception/GlobalApiExceptionHandler.java
+++ b/src/main/java/com/tumblermall/global/exception/GlobalApiExceptionHandler.java
@@ -5,14 +5,42 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+/**
+ * GlobalApiExceptionHandler handles exceptions thrown by REST controllers
+ * and converts them into standardized JSON API responses.
+ *
+ * <p>Responsibilities:
+ * <ul>
+ *   <li>Map BannerNotFoundException to a 404 Not Found response with a descriptive error message.</li>
+ *   <li>Map any other unhandled exceptions to a 500 Internal Server Error response.</li>
+ *   <li>Wrap error details in an ApiResponse.fail(...) structure.</li>
+ * </ul>
+ *
+ * <p>Use this handler for JSON/REST API endpoints.
+ *
+ * @author sharon
+ * @author whosoonhwang
+ */
 @RestControllerAdvice
 public class GlobalApiExceptionHandler {
 
+    /**
+     * Handle BannerNotFoundException by returning HTTP 404.
+     *
+     * @param e the BannerNotFoundException instance
+     * @return ResponseEntity with status 404 and a failure ApiResponse
+     */
     @ExceptionHandler(BannerNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleBannerNotFound(BannerNotFoundException e) {
         return ResponseEntity.status(404).body(ApiResponse.fail("배너 정보를 찾을 수 없습니다."));
     }
 
+    /**
+     * Handle any other Exception by returning HTTP 500.
+     *
+     * @param e the exception that was thrown
+     * @return ResponseEntity with status 500 and a generic failure ApiResponse
+     */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleDefault(Exception e) {
         return ResponseEntity.status(500).body(ApiResponse.fail("서버 오류 발생"));

--- a/src/main/java/com/tumblermall/global/exception/GlobalViewExceptionHandler.java
+++ b/src/main/java/com/tumblermall/global/exception/GlobalViewExceptionHandler.java
@@ -4,9 +4,31 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
 
+/**
+ * GlobalViewExceptionHandler handles exceptions thrown by MVC controllers
+ * and resolves them to a user-friendly error view.
+ *
+ * <p>Responsibilities:
+ * <ul>
+ *   <li>Catch all unhandled exceptions in MVC controllers.</li>
+ *   <li>Populate the error view with exception details.</li>
+ *   <li>Render the “error/error” template with an appropriate message.</li>
+ * </ul>
+ *
+ * <p>Use this handler for HTML-based UI endpoints.
+ *
+ * @author sharon
+ * @author whosoonhwang
+ */
 @ControllerAdvice
 public class GlobalViewExceptionHandler {
 
+    /**
+     * Handle any Exception thrown within MVC controllers.
+     *
+     * @param e the exception that was thrown
+     * @return a ModelAndView pointing to the error page with the exception message
+     */
     @ExceptionHandler(Exception.class)
     public ModelAndView handleViewException(Exception e) {
         ModelAndView mav = new ModelAndView("error/error");

--- a/src/main/java/com/tumblermall/global/exception/package-info.java
+++ b/src/main/java/com/tumblermall/global/exception/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Provides centralized exception handling for both MVC (view-based) and REST (API) layers of the application.
+ *
+ * <p>This package contains:
+ * <ul>
+ *   <li>{@link GlobalViewExceptionHandler} — handles exceptions thrown by Spring MVC controllers,
+ *       mapping them to user-friendly error views.</li>
+ *   <li>{@link GlobalApiExceptionHandler} — handles exceptions thrown by REST controllers,
+ *       mapping them to standardized JSON responses wrapped in {@link ApiResponse}.</li>
+ *   <li>{@link ApiResponse} — a generic wrapper for all API responses, encapsulating
+ *       status codes, messages, and payload data.</li>
+ *   <li>Optional enums or classes for error codes and metadata to ensure consistency
+ *       across the application’s error handling strategy.</li>
+ * </ul>
+ *
+ * <p>By centralizing exception logic here, controllers remain focused on business logic,
+ * and error responses—whether HTML views or JSON payloads—are consistent, maintainable,
+ * and easy to extend.
+ *
+ * @author whosoonhwang
+ */
+package com.tumblermall.global.exception;


### PR DESCRIPTION
## Add Description

- Document `GlobalViewExceptionHandler` with responsibilities and usage for MVC error views  
- Document `GlobalApiExceptionHandler` with responsibilities and usage for REST API error responses  
- Document `ApiResponse<T>` wrapper, including constructor and success/fail factory methods  
- Create `package-info.java` to outline the package’s purpose, core classes, and error handling strategy  

---

## Summary

This PR introduces detailed JavaDoc comments across the global exception handling classes and the `ApiResponse` wrapper, plus a new `package-info.java` to document the package’s purpose and core components. It also strengthens the `.gitignore` by excluding all IntelliJ IDEA configuration.

---

## Changes

- **JavaDoc Enhancements**  
  - `GlobalViewExceptionHandler`  
  - `GlobalApiExceptionHandler`  
  - `ApiResponse<T>` (constructor, factory methods)  
- **New File**  
  - `package-info.java` in `com.tumblermall.global.exception` to describe package responsibilities and main classes  
- **.gitignore Update**  
  - Ignore the entire `.idea/` directory  
  - Comment out previously specific `.idea` entries  

---

## Motivation

- Improves code readability and maintainability by clearly describing class responsibilities and public APIs.  
- Ensures IDE-specific files are not accidentally committed, keeping the repository clean and focused on source code.

---

## How to Review

1. Verify that all public classes in `src/main/java/com/tumblermall/global/exception/` now include accurate JavaDoc.  
2. Confirm `package-info.java` reflects the intended architecture and key components.  
3. Check that `.gitignore` properly excludes `.idea/` without affecting any required shared configuration.

---